### PR TITLE
Fix FieldList rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module "samproxy" {
         },
         {
           "name"  = "FieldList"
-          "value" = "['app.run']"
+          "value" = "['request.method', 'response.status_code']"
         },
         {
           "name"  = "UseTraceLength"

--- a/templates/rules.toml.tpl
+++ b/templates/rules.toml.tpl
@@ -3,6 +3,10 @@ Sampler = "DynamicSampler"
 %{ for sampler in samplers ~}
   [SamplerConfig.${sampler.dataset_name}]
   %{ for option in sampler.options ~}
-    ${option.name} = "${option.value}"
+    ${option.name} = ${ try(
+                          tonumber(option.value),
+                          tobool(option.value),
+                          length(regexall("\\[", option.value)) == 0 ? "\"${option.value}\"" : option.value,
+                      )}
   %{ endfor ~}
 %{ endfor ~}


### PR DESCRIPTION
## Description

Due to how Terraform treats types and backward compatibility, we are forced to have all the input options as strings( Terraform cannot handle different types in a map or list of objects), which leads to everything in the rules file being quoted. As reported in https://github.com/Vlaaaaaaad/terraform-aws-fargate-samproxy/issues/4, this is an issue for lists.

This PR "manually" tries to convert those string values to types. In case a list is detected, the quotes are removed thus creating a valid list in TOML.

## Notes

There are likely better fixes (or I hope so), but I have no idea what those are.

Closes https://github.com/Vlaaaaaaad/terraform-aws-fargate-samproxy/issues/4